### PR TITLE
fix(ci): lowercase Trivy image-ref + allow trufflehog AGPL action

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -21,3 +21,6 @@ jobs:
           comment-summary-in-pr: on-failure
           license-check: true
           deny-licenses: GPL-3.0, AGPL-3.0
+          # CI-only GitHub Actions are build tooling, not distributed deps, so their
+          # licenses do not contaminate the project. trufflehog is AGPL-3.0.
+          allow-dependencies-licenses: pkg:githubactions/trufflesecurity/trufflehog

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Trivy vulnerability scan
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
-          image-ref: ${{ github.event_name == 'pull_request' && format('{0}/{1}:pr-{2}', env.REGISTRY, env.IMAGE_NAME, github.event.pull_request.number) || fromJSON(steps.meta.outputs.json).tags[0] }}
+          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL,HIGH


### PR DESCRIPTION
## What

Fixes the two CI checks that were failing on the weekly Renovate PR (#34).

### 1. Trivy `Build & scan` -- invalid image reference
`docker.yml` built the scan target by hand:
```
ghcr.io/Sagargupta16/ai-project-template:pr-34
```
Docker references must be lowercase, so Trivy aborted:
```
FATAL  could not parse reference: ghcr.io/Sagargupta16/ai-project-template:pr-34
```
The image is actually built and `load`ed using `metadata-action`'s tags, which are auto-lowercased. Switched the scan `image-ref` to `fromJSON(steps.meta.outputs.json).tags[0]` -- the real loaded tag, valid in all events. Removes the redundant hand-built ref.

### 2. Dependency Review -- AGPL false positive
`deny-licenses: AGPL-3.0` flagged the `trufflehog` secret-scanner **GitHub Action**. CI-only actions are build tooling, not deps shipped in the artifact, so AGPL there doesn't contaminate the project. Allowed that single action via its PURL instead of weakening the policy.

## Testing

- Both workflow files validated with `yaml.safe_load`.
- Trivy ref now resolves to a lowercased tag for branch, PR, and tag events.

Once merged, Renovate #34 rebases clean.